### PR TITLE
Label Expression Error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,6 +177,7 @@ const readLabels = labelingInfo => {
     let labelStyle = readSymbol(labelDefinition.symbol);
     labelStyle.maxScale = labelDefinition.minScale || 1000;
     labelStyle.minScale = labelDefinition.maxScale || 0;
+    labelDefinition.labelExpression = || "";
     labelStyle.text = labelDefinition.labelExpression
       .replace(/\[/g, '{')
       .replace(/\]/g, '}')


### PR DESCRIPTION
When a Label Expression is null, an error is thrown.
Proposing defaulting the value to an empty string when it is null to avoid this error.