### PR TITLE
create SFS style when outline is null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol-esri-style",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Convert ESRI styles to OpenLayers styles",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -260,7 +260,7 @@ const readSymbol = symbol => {
         }
       };
     case 'esriSFS':
-      let style = readSymbol(symbol.outline);
+      let style = symbol.outline ? readSymbol(symbol.outline) : {};
       style.fill = { color: `rgba(${symbol.color.join(',')})` };
       return style;
     case 'esriPMS':


### PR DESCRIPTION
An error is thrown if a simple fill symbol has no outline defined. This PR fixes that.