### PR TITLE
fix: styleFunction - get property field

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export const createStyleFunction = (esriLayerInfoJson) => {
       const featureStyle = featureStyles.find(({ filters }) => {
         if (filters) {
           return filters.every(({ field, value, operator }) => {
-            const currentValue = feature.get(field);
+            const currentValue = feature.get(field) || '';
             switch (operator) {
               case 'in':
                 const valuesIn = value.split(',').map((value) => value.toString());


### PR DESCRIPTION
While using an ESRI FeatureServer with feature property of null, the following error occurs:

```
Uncaught TypeError: Cannot read properties of null (reading 'toString')
    at index.js:72
    at Array.every (<anonymous>)
    at index.js:67
```

This pull request fix this issue by using an empty string, if property value is null.