### PR TITLE
Remove private global variable mapProjection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ This module can convert ESRI style definition to OpenLayers style function. ESRI
 Import as ES6 module:
 
 ```javascript
-import { createStyleFunctionFromUrl, setMapProjection } from 'ol-esri-style';
+import { createStyleFunctionFromUrl } from 'ol-esri-style';
 
 // create a new vector layer
 const vector = new VectorLayer({
   ...
 });
 
-// This is need for labeling features. Visible resolutions for the labels are calculated using map projection units.
-setMapProjection(map.getView().getProjection());
 
 // set layer style
-createStyleFunctionFromUrl('arcgis_server_layer_url').then(styleFunction => {
+// Passing the projection is need for labeling features. Visible resolutions for
+// the labels are calculated using map projection units.
+createStyleFunctionFromUrl('arcgis_server_layer_url', map.getView().getProjection()).then(styleFunction => {
   vector.setStyle(styleFunction);
 });
 ```
@@ -33,7 +33,7 @@ createStyleFunctionFromUrl('arcgis_server_layer_url').then(styleFunction => {
     const styles = styleFunction(feature, resolution);
 
     // modify styles
-    
+
     return styles;
   });
 });

--- a/example/index.html
+++ b/example/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <body>

--- a/example/index.js
+++ b/example/index.js
@@ -1,69 +1,40 @@
 import 'ol/ol.css';
-import { createStyleFunction, createStyleFunctionFromUrl, setMapProjection } from '../src/index.js';
+import { createStyleFunctionFromUrl } from '../src/index.js';
 
 import Map from 'ol/Map.js';
 import View from 'ol/View.js';
-import EsriJSON from 'ol/format/EsriJSON.js';
+import GeoJSON from 'ol/format/GeoJSON';
 import VectorSource from 'ol/source/Vector.js';
 import OSM from 'ol/source/OSM.js';
 import { Tile as TileLayer, Vector as VectorLayer } from 'ol/layer.js';
-import { tile as tileStrategy } from 'ol/loadingstrategy.js';
-import { fromLonLat } from 'ol/proj.js';
-import { createXYZ } from 'ol/tilegrid.js';
 
 window.onload = async () => {
   const legend = document.getElementById('legend-items');
 
-  const esriJsonFormat = new EsriJSON();
-  const getResolutionFromScale = (scale) => {
-    return scale / (1 * 39.37 * (25.4 / 0.28));
-  };
+  const mapServiceUrl = 'https://services3.arcgis.com/GVgbJbqm8hXASVYi/ArcGIS/rest/services/2020_Earthquakes/FeatureServer';
 
-  // const mapServiceUrl = 'https://cors-anywhere.herokuapp.com/https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Petroleum/KSFields/FeatureServer/0';
-  const mapServiceUrl = 'http://pontechbg.asuscomm.com/arcgis/rest/services/TestSymbology/MapServer';
-
-  const responce = await fetch(`${mapServiceUrl}?f=json`);
-  const mapServiceDefinition = await responce.json();
+  const response = await fetch(`${mapServiceUrl}?f=json`);
+  const mapServiceDefinition = await response.json();
   const layerDefinitions = mapServiceDefinition.layers.map((l) => ({ ...l, url: `${mapServiceUrl}/${l.id}` }));
+
+  const view = new View({
+    center: [2600708.1109138425, 5281812.509330534],
+    zoom: 5,
+  });
 
   const mapServiceLayers = layerDefinitions.map((layerDefinition) => {
     const vectorSource = new VectorSource({
-      loader: async (extent, resolution, projection) => {
-        const geometry = encodeURIComponent(
-            `{"xmin":${extent[0]},"ymin":${extent[1]},"xmax":${extent[2]},"ymax":${extent[3]},"spatialReference":{"wkid":102100}}`
-          ),
-          url = `${layerDefinition.url}/query/?f=json&returnGeometry=true&spatialRel=esriSpatialRelIntersects&geometry=${geometry}&geometryType=esriGeometryEnvelope&inSR=102100&outFields=*&outSR=102100`;
-
-        const responce = await fetch(url);
-        const responeJson = await responce.json();
-
-        if (responeJson.error) {
-          console.log(responeJson);
-        } else {
-          const features = esriJsonFormat.readFeatures(responeJson, {
-            featureProjection: projection,
-          });
-          if (features.length > 0) {
-            vectorSource.addFeatures(features);
-          }
-        }
-      },
-      strategy: tileStrategy(
-        createXYZ({
-          tileSize: 512,
-        })
-      ),
+      format: new GeoJSON(),
+      url: `${layerDefinition.url}/query?where=1%3D1&outFields=*&returnGeometry=true&f=geojson`,
     });
 
     const vector = new VectorLayer({
       source: vectorSource,
       visible: layerDefinition.defaultVisibility,
-      minResolution: getResolutionFromScale(layerDefinition.maxScale || Number.MAX_VALUE),
-      maxResolution: getResolutionFromScale(layerDefinition.minScale),
     });
     vector.setProperties({ layerDefinition });
 
-    createStyleFunctionFromUrl(layerDefinition.url).then((styleFunction) => {
+    createStyleFunctionFromUrl(layerDefinition.url, view.getProjection()).then((styleFunction) => {
       vector.setStyle(styleFunction);
     });
 
@@ -110,15 +81,8 @@ window.onload = async () => {
   const map = new Map({
     layers: [raster, ...mapServiceLayers],
     target: document.getElementById('map'),
-    view: new View({
-      //center: fromLonLat([-98.293401, 38.646303]),
-      //  center: fromLonLat([23.3, 42.7]),
-      center: [2600708.1109138425, 5281812.509330534],
-      zoom: 10,
-    }),
+    view,
   });
-
-  setMapProjection(map.getView().getProjection());
 
   window.map = map;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ const lineDashPattern = {
 /**
  * Creates OpenLayers style function based on ESRI drawing info
  * @param {!String} layerUrl - ArcGIS REST URL to the layer
- * @return {Promise<Function>} function which styles features
+ * @param {import('ol/proj/Projection')} [projection] - visibility of the labels are calculated using this projection units
+ * @return {Promise<Function>} function used to style features
  */
 export const createStyleFunctionFromUrl = async(layerUrl, mapProjection) => {
     const responce = await fetch(`${layerUrl}?f=json`);
@@ -31,7 +32,8 @@ export const createStyleFunctionFromUrl = async(layerUrl, mapProjection) => {
  * @param {!Object} esriLayerInfoJson
  * @param {import('./types').EsriRenderer} esriLayerInfoJson.renderer - see https://developers.arcgis.com/documentation/common-data-types/renderer-objects.htm for more info
  * @param {Array<import('./types').EsriLabelDefinition>} esriLayerInfoJson.labelingInfo - see https://developers.arcgis.com/documentation/common-data-types/labeling-objects.htm for more info
- * @return {Promise<Function>} function which styles features
+ * @param {import('ol/proj/Projection')} [projection] - visibility of the labels are calculated using this projection units
+ * @return {Promise<Function>} function used to style features
  */
 export const createStyleFunction = async(esriLayerInfoJson, mapProjection) => {
     let { featureStyles, labelStyles } = readEsriStyleDefinitions(esriLayerInfoJson.drawingInfo);


### PR DESCRIPTION
This solves #30 however it also introduces an API breaking change. This is what happened:

* `mapProjection` private global is removed
* functions `createStyleFunction` and `createStyleFunctionFromUrl` now accept an optional `mapProjection` argument that gets passed down the call stack to where it is needed. This Change is backwards compatible.
* function `setMapProjection` is deleted since it is no longer used. This change is backards incompatible.
* README is updated with the new changes.
* example is updated and fixed. Previously it didn't work because the specified source did not respond. I replaced this with an arcgisonline layer and simplified the code a little bit, so that it can be helpful to other by having less noise.

## Questions

* Should the `setMapProjection` function be left with a warning for backwards compatibility?