### PR TITLE
add esriColorToOLColor method

### DIFF
--- a/tests/readSymbol.test.js
+++ b/tests/readSymbol.test.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { readSymbol } from '../src/index.js';
+import { esriColorToOLColor, readSymbol } from '../src/index.js';
 
 describe('[readSymbol() tests]', () => {
     it('should throw exception if symbol type is not defined', () => {
@@ -21,7 +21,7 @@ describe('[readSymbol() tests]', () => {
 
         assert.isDefined(symbol);
         assert.isDefined(symbol.stroke);
-        assert.equal(symbol.stroke.color, `rgba(${symbolDefinition.color.join(',')})`);
+        assert.equal(symbol.stroke.color, `rgba(${esriColorToOLColor(symbolDefinition.color).join(',')})`);
         assert.equal(symbol.stroke.width, symbolDefinition.width);
         assert.isArray(symbol.stroke.lineDash);
         assert.isEmpty(symbol.stroke.lineDash);
@@ -39,7 +39,7 @@ describe('[readSymbol() tests]', () => {
 
         assert.isDefined(symbol);
         assert.isDefined(symbol.stroke);
-        assert.equal(symbol.stroke.color, `rgba(${symbolDefinition.color.join(',')})`);
+        assert.equal(symbol.stroke.color, `rgba(${esriColorToOLColor(symbolDefinition.color).join(',')})`);
         assert.equal(symbol.stroke.width, symbolDefinition.width);
         assert.isArray(symbol.stroke.lineDash);
         assert.equal(symbol.stroke.lineDash.length, 1);
@@ -57,7 +57,7 @@ describe('[readSymbol() tests]', () => {
 
         assert.isDefined(symbol);
         assert.isDefined(symbol.fill);
-        assert.equal(symbol.fill.color, `rgba(${symbolDefinition.color.join(',')})`);
+        assert.equal(symbol.fill.color, `rgba(${esriColorToOLColor(symbolDefinition.color).join(',')})`);
     });
 
     it('should read esriSFS symbol with stroke', () => {
@@ -77,7 +77,7 @@ describe('[readSymbol() tests]', () => {
 
         assert.isDefined(symbol);
         assert.isDefined(symbol.fill);
-        assert.equal(symbol.fill.color, `rgba(${symbolDefinition.color.join(',')})`);
+        assert.equal(symbol.fill.color, `rgba(${esriColorToOLColor(symbolDefinition.color).join(',')})`);
         assert.isDefined(symbol.stroke);
         assert.equal(symbol.stroke.width, symbolDefinition.outline.width);
         assert.isArray(symbol.stroke.lineDash);
@@ -148,7 +148,7 @@ describe('[readSymbol() tests]', () => {
         assert.equal(symbol.textBaseline, symbolDefinition.verticalAlignment);
         assert.equal(symbol.angle, symbolDefinition.angle);
         assert.isDefined(symbol.fill);
-        assert.equal(symbol.fill.color, `rgba(${symbolDefinition.color.join(',')})`);
+        assert.equal(symbol.fill.color, `rgba(${esriColorToOLColor(symbolDefinition.color).join(',')})`);
         assert.isNull(symbol.stroke);
         assert.isNull(symbol.backgroundFill);
         assert.isNull(symbol.backgroundStroke);

--- a/tests/styles.test.js
+++ b/tests/styles.test.js
@@ -1,6 +1,6 @@
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { createFeatureStyle, createLabelStyle } from '../src/styles.js';
-import { readEsriStyleDefinitions } from '../src/index.js';
+import { readEsriStyleDefinitions, esriColorToOLColor } from '../src/index.js';
 
 describe('[src/styles.js tests]', () => {
     const drawingInfo = {
@@ -17,82 +17,82 @@ describe('[src/styles.js tests]', () => {
             },
             defaultLabel: '<all other values>',
             uniqueValueInfos: [{
-                    symbol: {
-                        type: 'esriSLS',
-                        style: 'esriSLSSolid',
-                        color: [255, 255, 0, 255],
-                        width: 1.5,
-                    },
-                    value: '7,2',
-                    label: '6 kV, Кабелна линия',
-                    description: '',
+                symbol: {
+                    type: 'esriSLS',
+                    style: 'esriSLSSolid',
+                    color: [255, 255, 0, 255],
+                    width: 1.5,
                 },
-                {
-                    symbol: {
-                        type: 'esriSLS',
-                        style: 'esriSLSDashDot',
-                        color: [197, 0, 255, 255],
-                        width: 1.5,
-                    },
-                    value: '6,3',
-                    label: '10 kV, Въздушна изолирана линия',
-                    description: '',
+                value: '7,2',
+                label: '6 kV, Кабелна линия',
+                description: '',
+            },
+            {
+                symbol: {
+                    type: 'esriSLS',
+                    style: 'esriSLSDashDot',
+                    color: [197, 0, 255, 255],
+                    width: 1.5,
                 },
-                {
-                    symbol: {
-                        type: 'esriSLS',
-                        style: 'esriSLSDash',
-                        color: [197, 0, 255, 255],
-                        width: 1.7,
-                    },
-                    value: '6,1',
-                    label: '10 kV, Въздушна линия',
-                    description: '',
+                value: '6,3',
+                label: '10 kV, Въздушна изолирана линия',
+                description: '',
+            },
+            {
+                symbol: {
+                    type: 'esriSLS',
+                    style: 'esriSLSDash',
+                    color: [197, 0, 255, 255],
+                    width: 1.7,
                 },
-                {
-                    symbol: {
-                        type: 'esriSLS',
-                        style: 'esriSLSSolid',
-                        color: [197, 0, 255, 255],
-                        width: 1.5,
-                    },
-                    value: '6,2',
-                    label: '10 kV, Кабелна линия',
-                    description: '',
+                value: '6,1',
+                label: '10 kV, Въздушна линия',
+                description: '',
+            },
+            {
+                symbol: {
+                    type: 'esriSLS',
+                    style: 'esriSLSSolid',
+                    color: [197, 0, 255, 255],
+                    width: 1.5,
                 },
-                {
-                    symbol: {
-                        type: 'esriSLS',
-                        style: 'esriSLSDashDot',
-                        color: [255, 0, 0, 255],
-                        width: 1.5,
-                    },
-                    value: '5,3',
-                    label: '20 kV, Въздушна изолирана линия',
-                    description: '',
+                value: '6,2',
+                label: '10 kV, Кабелна линия',
+                description: '',
+            },
+            {
+                symbol: {
+                    type: 'esriSLS',
+                    style: 'esriSLSDashDot',
+                    color: [255, 0, 0, 255],
+                    width: 1.5,
                 },
-                {
-                    symbol: {
-                        type: 'esriSLS',
-                        style: 'esriSLSDash',
-                        color: [255, 0, 0, 255],
-                        width: 1.5,
-                    },
-                    value: '5,1',
-                    label: '20 kV, Въздушна линия',
-                    description: '',
+                value: '5,3',
+                label: '20 kV, Въздушна изолирана линия',
+                description: '',
+            },
+            {
+                symbol: {
+                    type: 'esriSLS',
+                    style: 'esriSLSDash',
+                    color: [255, 0, 0, 255],
+                    width: 1.5,
                 },
-                {
-                    symbol: {
-                        type: 'esriSLS',
-                        style: 'esriSLSSolid',
-                        color: [255, 0, 0, 255],
-                        width: 1.5,
-                    },
-                    value: '5,2',
-                    label: '20 kV, Кабелна линия',
-                    description: '',
+                value: '5,1',
+                label: '20 kV, Въздушна линия',
+                description: '',
+            },
+            {
+                symbol: {
+                    type: 'esriSLS',
+                    style: 'esriSLSSolid',
+                    color: [255, 0, 0, 255],
+                    width: 1.5,
                 },
+                value: '5,2',
+                label: '20 kV, Кабелна линия',
+                description: '',
+            },
             ],
             fieldDelimiter: ',',
         },
@@ -127,7 +127,7 @@ describe('[src/styles.js tests]', () => {
             },
             minScale: 10000,
             maxScale: 0,
-        }, ],
+        },],
     };
     let styleDefinition;
 
@@ -141,7 +141,7 @@ describe('[src/styles.js tests]', () => {
         assert.equal(styleDefinition.labelStyles.length, 1);
     });
 
-    it('should create feature style', async() => {
+    it('should create feature style', async () => {
         const style = await createFeatureStyle(styleDefinition.featureStyles[1]);
         const labelStyle = createLabelStyle(styleDefinition.labelStyles[0]);
 
@@ -150,11 +150,43 @@ describe('[src/styles.js tests]', () => {
         assert.isNull(style.getImage());
         assert.isNull(style.getText());
         assert.isDefined(style.getStroke());
-        assert.equal(style.getStroke().getColor(), `rgba(${drawingInfo.renderer.uniqueValueInfos[1].symbol.color.join()})`);
+        assert.equal(style.getStroke().getColor(), `rgba(${esriColorToOLColor(drawingInfo.renderer.uniqueValueInfos[1].symbol.color).join()})`);
         assert.isArray(style.getStroke().getLineDash());
         assert.equal(style.getStroke().getLineDash()[0], 10);
         assert.equal(style.getStroke().getWidth(), drawingInfo.renderer.uniqueValueInfos[1].symbol.width);
 
         assert.isDefined(labelStyle);
+    });
+
+    it('should normalize alpha value to 0-1', async () => {
+        let result = esriColorToOLColor([255, 255, 255, 255]);
+
+        assert.isDefined(result);
+        assert.isArray(result);
+        assert.equal(result.length, 4);
+        assert.equal(result[0], 255);
+        assert.equal(result[1], 255);
+        assert.equal(result[2], 255);
+        assert.equal(result[3], 1.0); // normalized alpha
+
+        result = esriColorToOLColor([0, 0, 0, 0]);
+
+        assert.isDefined(result);
+        assert.isArray(result);
+        assert.equal(result.length, 4);
+        assert.equal(result[0], 0);
+        assert.equal(result[1], 0);
+        assert.equal(result[2], 0);
+        assert.equal(result[3], 0.0); // normalized alpha
+
+        result = esriColorToOLColor([0, 0, 0, 127]);
+
+        assert.isDefined(result);
+        assert.isArray(result);
+        assert.equal(result.length, 4);
+        assert.equal(result[0], 0);
+        assert.equal(result[1], 0);
+        assert.equal(result[2], 0);
+        expect(result[3]).to.be.closeTo(0.49, 0.01); // normalized alpha
     });
 });


### PR DESCRIPTION
`esriColorToOLColor()` normalizes the alpha value from the ESRI format (0-255) to the OpenLayers format (0-1) by dividing it by 255.